### PR TITLE
Network Bug Fix

### DIFF
--- a/tool/tools.go
+++ b/tool/tools.go
@@ -35,7 +35,7 @@ func CheckIsAddress(address string) bool {
 	if CheckIsString(&address) == false {
 		return false
 	}
-	_, err := btcutil.DecodeAddress(address, &chaincfg.TestNet3Params)
+	_, err := btcutil.DecodeAddress(address, GetCoreNet())
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
This PR:
 - Removes hardcoded network param in the `CheckIsAddress` method in `tools.go`.